### PR TITLE
Fix uint cast for audio event listener

### DIFF
--- a/ios/RNInCallManager/RNInCallManager.swift
+++ b/ios/RNInCallManager/RNInCallManager.swift
@@ -377,7 +377,7 @@ class RNInCallManager: NSObject, AVAudioPlayerDelegate {
         self.audioSessionRouteChangeObserver = self.startObserve(AVAudioSessionRouteChangeNotification, object: nil, queue: nil) { notification in
             guard notification.name == AVAudioSessionRouteChangeNotification && notification.userInfo != nil else { return }
 
-            if let rawValue = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as ? UInt {
+            if let rawValue = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt {
                 if let type = AVAudioSessionRouteChangeReason(rawValue: rawValue) {
                     switch type {
                         case .Unknown:

--- a/ios/RNInCallManager/RNInCallManager.swift
+++ b/ios/RNInCallManager/RNInCallManager.swift
@@ -377,7 +377,7 @@ class RNInCallManager: NSObject, AVAudioPlayerDelegate {
         self.audioSessionRouteChangeObserver = self.startObserve(AVAudioSessionRouteChangeNotification, object: nil, queue: nil) { notification in
             guard notification.name == AVAudioSessionRouteChangeNotification && notification.userInfo != nil else { return }
 
-            if let rawValue = notification.userInfo?[AVAudioSessionRouteChangeReasonKey]?.unsignedIntegerValue {
+            if let rawValue = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as ? UInt {
                 if let type = AVAudioSessionRouteChangeReason(rawValue: rawValue) {
                     switch type {
                         case .Unknown:


### PR DESCRIPTION
The WiredHeadset event was not being fired because the case from optional(int) to uint was failing. A slightly different syntax is required.
