### PR TITLE
ADD startInCallProximity() and stopInCallProximity()

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,35 +23,35 @@ you can find demo here: https://github.com/oney/RCTWebRTCDemo
 
 #### BREAKING NOTE:
 
-* since `2.1.0`, you should use `RN 40+` and upgrade your xcode to support `swift 3`.  
-  after upgrading xcode, `Edit -> Convert -> To Current Swift Syntax` to invoke `Swift Migration Assistant`  
+* since `2.1.0`, you should use `RN 40+` and upgrade your xcode to support `swift 3`.
+  after upgrading xcode, `Edit -> Convert -> To Current Swift Syntax` to invoke `Swift Migration Assistant`
   see [Migrating to Swift 2.3 or Swift 3 from Swift 2.2](https://swift.org/migration-guide/)
- 
+
 * for old RN versions (RN < 0.40) please use version `1.5.4` ( Swift 2.2~2.3 )
 
 
-**from npm package**: `npm install react-native-incall-manager`  
-**from git package**: `npm install git://github.com/zxcpoiu/react-native-incall-manager.git`  
+**from npm package**: `npm install react-native-incall-manager`
+**from git package**: `npm install git://github.com/zxcpoiu/react-native-incall-manager.git`
 
 ===================================================
 #### android:
 
-After install, you can use `rnpm` (`npm install rnpm -g`) to link android.  
+After install, you can use `rnpm` (`npm install rnpm -g`) to link android.
 use `rnpm link react-native-incall-manager` to link or manually if you like.
 
 **optional sound files on android**
-if you want to use bundled ringtone/ringback/busytone sound instead of system sound 
-  
-We use android support library v4 to check/request permissions.  
-You should add `compile "com.android.support:support-v4:23.0.1"` in `$your_project/android/app/build.gradle` dependencies on android.  
-  
+if you want to use bundled ringtone/ringback/busytone sound instead of system sound
+
+We use android support library v4 to check/request permissions.
+You should add `compile "com.android.support:support-v4:23.0.1"` in `$your_project/android/app/build.gradle` dependencies on android.
+
 put files in `android/app/src/main/res/raw`
 and rename file correspond to sound type:
 
 ```
-incallmanager_busytone.mp3  
-incallmanager_ringback.mp3  
-incallmanager_ringtone.mp3 
+incallmanager_busytone.mp3
+incallmanager_ringback.mp3
+incallmanager_ringtone.mp3
 ```
 
 on android, as long as your file extension supported by android, this module will load it.
@@ -61,7 +61,7 @@ on android, as long as your file extension supported by android, this module wil
 
 #### ios:
 
-since ios part written in swift and it doesn't support static library yet.  
+since ios part written in swift and it doesn't support static library yet.
 before that, you should add this project manually:
 
 - **Add files in to your project:**
@@ -73,12 +73,12 @@ before that, you should add this project manually:
     * right click on your_project directory, `add files` to your project and add `node_modules/react-native-incall-manager/ios/RNInCallManager/`
   4. on the pou-up window, uncheck `Copy items if needed` and select `Added folders: Create groups` then add it. you will see a new directory named `RNInCallmanager under your_project` directory.
 
-- **Setup Objective-C Bridging Header:**  
+- **Setup Objective-C Bridging Header:**
   1. click your `project's xcodeproject root`, go to `build setting` and search `Objective-C Bridging Header`
   2. set you header location, the default path is: `ReactNativeProjectRoot/ios/`, in this case, you should set `../node_modules/react-native-incall-manager/ios/RNInCallManager/RNInCallManager-Bridging-Header.h`
 
 **optional sound files on android**
-if you want to use bundled ringtone/ringback/busytone sound instead of system sound 
+if you want to use bundled ringtone/ringback/busytone sound instead of system sound
 
 1. add files into your_project directory under your project's xcodeproject root. ( or drag into it as described above. )
 2. check `copy file if needed`
@@ -86,8 +86,8 @@ if you want to use bundled ringtone/ringback/busytone sound instead of system so
 
 ```
 incallmanager_busytone.mp3
-incallmanager_ringback.mp3 
-incallmanager_ringtone.mp3 
+incallmanager_ringback.mp3
+incallmanager_ringtone.mp3
 ```
 
 on ios, we only support mp3 files currently.
@@ -99,7 +99,7 @@ This module implement a basic handle logic automatically, just:
 ```javascript
 import InCallManager from 'react-native-incall-manager';
 
-// --- start manager when the chat start based on logics of your app 
+// --- start manager when the chat start based on logics of your app
 // On Call Established:
 InCallManager.start({media: 'audio'}); // audio/video, default: audio
 
@@ -159,6 +159,16 @@ DeviceEventEmitter.addListener('Proximity', function (data) {
 
 ```
 
+if you want to use the proximity sensor:
+
+```javascript
+// ringback is basically for OUTGOING call. and is part of start().
+
+InCallManager.startInCallProximity({media: 'audio'});
+//when the call is terminated you can release the proximity status
+InCallManager.stopInCallProximity();
+```
+
 ## About Permission:
 
 
@@ -188,7 +198,7 @@ if (InCallManager.recordPermission !== 'granted') {
 }
 ```
 
-We use android support library v4 to check/request permissions.  
+We use android support library v4 to check/request permissions.
 You should add `compile "com.android.support:support-v4:23.0.1"` in `$your_project/android/app/build.gradle` dependencies on android.
 
 
@@ -196,11 +206,11 @@ You should add `compile "com.android.support:support-v4:23.0.1"` in `$your_proje
 
 React Native does not officially support api 23 currently ( it is on api 22 now. see: [RN known issues](https://facebook.github.io/react-native/docs/known-issues.html#android-m-permissions)) and android supports request permission at runtime since api 23, so it will always return 'granted' immediately after calling `checkRecordPermission()` or `requestRecordPermission()`.
 
-If you really need the functionality, you can do the following to make them work but at your own risk:  
+If you really need the functionality, you can do the following to make them work but at your own risk:
 ( I've tested it though, but who knows :) )
 
-Step 1: change your `targetSdkVersion` to 23 in `$your_project/android/app/build.gradle`  
-Step 2: override `onRequestPermissionsResult` in your `MainActivity.java` like:  
+Step 1: change your `targetSdkVersion` to 23 in `$your_project/android/app/build.gradle`
+Step 2: override `onRequestPermissionsResult` in your `MainActivity.java` like:
 
 ```
     @Override
@@ -214,9 +224,9 @@ then you can test it on android 6 now.
 
 **Another thing you should know is:**
 
-If you change targetSdkVersion to 23, the `red box` which React Native used to display errors in development mode requires permission `Draw Over Other Apps`.  
-So in **development mode**, you should manually grant permission in `app settings` on your device or declare `android.permission.SYSTEM_ALERT_WINDOW` in your manifest.  
-You don't have to do this in **release mode** since there are no red box.  
+If you change targetSdkVersion to 23, the `red box` which React Native used to display errors in development mode requires permission `Draw Over Other Apps`.
+So in **development mode**, you should manually grant permission in `app settings` on your device or declare `android.permission.SYSTEM_ALERT_WINDOW` in your manifest.
+You don't have to do this in **release mode** since there are no red box.
 
 
 checkout this awesome project: [react-native-android-permissions](https://github.com/lucasferreira/react-native-android-permissions) by @lucasferreira for more information.
@@ -224,7 +234,7 @@ checkout this awesome project: [react-native-android-permissions](https://github
 
 ## Automatic Basic Behavior:
 
-**on start:**  
+**on start:**
 * store current settings, set KeepScreenOn flag = true, and register some event listeners.
 * if media type is `audio`, route voice to earpiece, otherwise route to speaker.
 * audio will enable proximity sensor which is disabled by default if media=video
@@ -232,12 +242,12 @@ checkout this awesome project: [react-native-android-permissions](https://github
 * when newly external device plugged, such as wired-headset, route audio to external device.
 * optional play ringback
 
-**on stop:**  
+**on stop:**
 
 * set KeepScreenOn flag = false, remote event listeners, restore original user settings.
 * optional play busytone
 
-## Custom Behavior:  
+## Custom Behavior:
 
 you can custom behavior use API/events exposed by this module. see `API` section.
 

--- a/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
@@ -763,6 +763,36 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
         releaseAudioFocus();
     }
 
+    @ReactMethod
+    public void startInCallProximity(final String _media) {
+        media = _media;
+        if (media.equals("video")) {
+            defaultSpeakerOn = true;
+        } else {
+            defaultSpeakerOn = false;
+        }
+        requestAudioFocus();
+        startWiredHeadsetEvent();
+        startNoisyAudioEvent();
+        startMediaButtonEvent();
+        if (!defaultSpeakerOn) {
+            // video, default disable proximity
+            startProximitySensor();
+        }
+        setKeepScreenOn(true);
+    }
+
+    @ReactMethod
+    public void stopInCallProximity() {
+        stopWiredHeadsetEvent();
+        stopNoisyAudioEvent();
+        stopMediaButtonEvent();
+        stopProximitySensor();
+        setKeepScreenOn(false);
+        turnScreenOn();
+        releaseAudioFocus();
+    }
+
     private void requestAudioFocus() {
         if (!isAudioFocused) {
             int result = audioManager.requestAudioFocus(mOnFocusChangeListener, AudioManager.STREAM_VOICE_CALL, AudioManager.AUDIOFOCUS_GAIN);
@@ -889,7 +919,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
             public void run() {
                 Activity mCurrentActivity = getCurrentActivity();
                 if (mCurrentActivity == null) {
-                    Log.d(TAG, "ReactContext doesn't hava any Activity attached.");
+                    Log.d(TAG, "ReactContext doesn't have any Activity attached.");
                     return;
                 }
                 Window window = mCurrentActivity.getWindow();
@@ -934,8 +964,8 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
         }
     }
 
-    /** 
-     * This is part of start() process. 
+    /**
+     * This is part of start() process.
      * ringbackUriType must not empty. empty means do not play.
      */
     public void startRingback(final String ringbackUriType) {
@@ -964,7 +994,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
                 ringbackUri = getRingbackUri(ringbackUriType);
                 if (ringbackUri == null) {
                     Log.d(TAG, "startRingback(): no available media");
-                    return;    
+                    return;
                 }
             }
 
@@ -982,7 +1012,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
             mRingback.startPlay(data);
         } catch(Exception e) {
             Log.d(TAG, "startRingback() failed");
-        }   
+        }
     }
 
     @ReactMethod
@@ -994,11 +1024,11 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
             }
         } catch(Exception e) {
             Log.d(TAG, "stopRingback() failed");
-        }   
+        }
     }
 
-    /** 
-     * This is part of start() process. 
+    /**
+     * This is part of start() process.
      * busytoneUriType must not empty. empty means do not play.
      * return false to indicate play tone failed and should be stop() immediately
      * otherwise, it will stop() after a tone completed.
@@ -1029,7 +1059,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
                 busytoneUri = getBusytoneUri(busytoneUriType);
                 if (busytoneUri == null) {
                     Log.d(TAG, "startBusytone(): no available media");
-                    return false;    
+                    return false;
                 }
             }
 
@@ -1050,7 +1080,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
             Log.d(TAG, "startBusytone() failed");
             Log.d(TAG, e.getMessage());
             return false;
-        }   
+        }
     }
 
     public void stopBusytone() {
@@ -1061,7 +1091,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
             }
         } catch(Exception e) {
             Log.d(TAG, "stopBusytone() failed");
-        }   
+        }
     }
 
     @ReactMethod
@@ -1088,7 +1118,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
             Uri ringtoneUri = getRingtoneUri(ringtoneUriType);
             if (ringtoneUri == null) {
                 Log.d(TAG, "startRingtone(): no available media");
-                return;    
+                return;
             }
 
             storeOriginalAudioSetup();
@@ -1125,7 +1155,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
         } catch(Exception e) {
             releaseFullWakeLock();
             Log.d(TAG, "startRingtone() failed");
-        }   
+        }
     }
 
     @ReactMethod
@@ -1143,7 +1173,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
             releaseFullWakeLock();
         } catch(Exception e) {
             Log.d(TAG, "stopRingtone() failed");
-        }   
+        }
     }
 
     private void setMediaPlayerEvents(MediaPlayer mp, final String name) {
@@ -1154,7 +1184,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
             public boolean onError(MediaPlayer mp, int what, int extra) {
                 Log.d(TAG, String.format("MediaPlayer %s onError(). what: %d, extra: %d", name, what, extra));
                 //return True if the method handled the error
-                //return False, or not having an OnErrorListener at all, will cause the OnCompletionListener to be called. Get news & tips 
+                //return False, or not having an OnErrorListener at all, will cause the OnCompletionListener to be called. Get news & tips
                 return true;
             }
         });
@@ -1180,7 +1210,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
                     audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
                 } else if (name.equals("mRingtone")) {
                     audioManager.setMode(AudioManager.MODE_RINGTONE);
-                } 
+                }
                 updateAudioRoute();
                 mp.start();
             }
@@ -1260,7 +1290,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
         String type;
         // --- _type would never be empty here. just in case.
         if (_type.equals("_DEFAULT_") ||  _type.isEmpty()) {
-            //type = fileSysWithExt; // --- 
+            //type = fileSysWithExt; // ---
             return getDefaultUserUri("defaultBusytoneUri");
         } else {
             type = _type;
@@ -1447,7 +1477,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
                             audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
                         } else if (caller.equals("mRingtone")) {
                             audioManager.setMode(AudioManager.MODE_RINGTONE);
-                        } 
+                        }
                         InCallManagerModule.this.updateAudioRoute();
 
                         tg.startTone(toneType);

--- a/index.js
+++ b/index.js
@@ -55,7 +55,6 @@ class InCallManager {
         }
     }
 
-
     setKeepScreenOn(enable) {
         enable = (enable === true) ? true : false;
         _InCallManager.setKeepScreenOn(enable);
@@ -104,6 +103,20 @@ class InCallManager {
     stopRingback() {
         _InCallManager.stopRingback();
     }
+
+    startInCallProximity(setup) {
+        if (Platform.OS === 'android') {
+            let media = (setup.media === 'video') ? 'video' : 'audio';
+            _InCallManager.startInCallProximity(media);
+        }
+    }
+
+    stopInCallProximity() {
+        if (Platform.OS === 'android') {
+            _InCallManager.stopInCallProximity();
+        }
+    }
+
 
     async checkRecordPermission() {
         // --- on android which api < 23, it will always be "granted"


### PR DESCRIPTION
- Allow users to control only the proximity sensor during a call

@zxcpoiu In my app I use a library which already set the audio Mode and reset it.
Using that library and this one together conflicts and reset the audio to a wrong original value.

I have added explicit calls to only use proximity, since that is the part I need and it was not exposed.

I hope if makes sense