### PR TITLE
Handle RN 0.47 breaking change (createJSModules)

### DIFF
--- a/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerPackage.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerPackage.java
@@ -16,7 +16,7 @@ public class InCallManagerPackage implements ReactPackage {
         return Collections.<NativeModule>singletonList(new InCallManagerModule(reactContext));
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
RN 0.47 removed createJSModules from ReactPackage [commit](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8)