### PR TITLE
update torch with swift 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ note: ios only supports `auto` currently.
 | startRingtone(`ringtone: string, ?vibrate_pattern: array, ?ios_category: string, ?seconds: number`)   | :smile: | :smile: | play ringtone. </br>`ringtone`: '_DEFAULT_' or '_BUNDLE_'</br>`vibrate_pattern`: same as RN, but does not support repeat</br>`ios_category`: ios only, if you want to use specific audio category</br>`seconds`: android only, specify how long do you want to play rather than play once nor repeat. in sec.|
 | stopRingtone()   | :smile: | :smile: | stop play ringtone if previous started via `startRingtone()` |
 | stopRingback()   | :smile: | :smile: | stop play ringback if previous started via `start()` |
-| setFlashOn(`enable: ?boolean, brightness: ?number`)  | :rage: | :smile: | set flash light on/off |
+| setFlashOn(`enable: ?boolean, brightness: ?number`)  | :rage: | :smile: | set flash light on/off</br>`enable`:enable/disable flash</br>`brightness`:number between 0.0 and 1.0, defaults to max brightness|
 | async getIsWiredHeadsetPluggedIn()  | :rage: | :smile: | return wired headset plugged in state |
 
 

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ class InCallManager {
     setFlashOn(enable, brightness) {
         if (Platform.OS === 'ios') {
             enable = (enable === true) ? true : false;
-            brightness = (typeof brightness === 'number') ? brightness : 0;
+            brightness = (typeof brightness === 'number') ? brightness : 1;
             _InCallManager.setFlashOn(enable, brightness);
         } else {
             console.log("Android doesn't support setFlashOn(enable, brightness)");

--- a/ios/RNInCallManager/RNInCallManager.swift
+++ b/ios/RNInCallManager/RNInCallManager.swift
@@ -259,17 +259,17 @@ class RNInCallManager: NSObject, AVAudioPlayerDelegate {
         }
     }
 
-    @objc func setFlashOn(enable: Bool, brightness: NSNumber) -> Void {
+    @objc func setFlashOn(_ enable: Bool, brightness: NSNumber) -> Void {
         guard let device = device else { return }
-        if device.hasTorch && device.position == .back {
+        if device.hasTorch && device.isTorchAvailable && device.position == .back {
             do {
                 try device.lockForConfiguration()
                 if enable {
-                    try device.setTorchModeOnWithLevel(brightness.floatValue)
+                    try device.setTorchModeOnWithLevel(min(brightness.floatValue, AVCaptureMaxAvailableTorchLevel))
                 } else {
                     device.torchMode = .off
                 }
-                NSLog("RNInCallManager.setForceSpeakerphoneOn(): enable: \(enable)")
+                NSLog("RNInCallManager.setFlashOn(): enable: \(enable)")
                 device.unlockForConfiguration()
             } catch let error {
                 NSLog("RNInCallManager.setFlashOn error != \(error)")


### PR DESCRIPTION
Resolves crashes with "is-not-a-recognized-objective-c-method" when using torch.

Also:
Changed brightness to default to max.
Use device's max brightness when manual brightness level is set too high (instead of error). The max brightness can be lower sometimes due to device temperature etc

Somewhat related to issue #53.