### PR TITLE
Make startRingback public function

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Note: ios only supports `auto` currently.
 | async getAudioUriJS()   | :smile: | :smile: | get audio Uri path. this would be useful when you want to pass Uri into another module. |
 | startRingtone(`ringtone: string, ?vibrate_pattern: array, ?ios_category: string, ?seconds: number`)   | :smile: | :smile: | play ringtone. </br>`ringtone`: '_DEFAULT_' or '_BUNDLE_'</br>`vibrate_pattern`: same as RN, but does not support repeat</br>`ios_category`: ios only, if you want to use specific audio category</br>`seconds`: android only, specify how long do you want to play rather than play once nor repeat. in sec.|
 | stopRingtone()   | :smile: | :smile: | stop play ringtone if previous started via `startRingtone()` |
+| startRingback(`ringtone: string`)   | :smile: | :smile: | start play ringback </br>`ringtone`: '_DEFAULT_' or '_BUNDLE_'</br> |
 | stopRingback()   | :smile: | :smile: | stop play ringback if previous started via `start()` |
 | setFlashOn(`enable: ?boolean, brightness: ?number`)  | :rage: | :smile: | set flash light on/off |
 | async getIsWiredHeadsetPluggedIn()  | :rage: | :smile: | return wired headset plugged in state |

--- a/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
@@ -806,6 +806,7 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
      * This is part of start() process. 
      * ringbackUriType must not empty. empty means do not play.
      */
+    @ReactMethod
     public void startRingback(final String ringbackUriType) {
         if (ringbackUriType.isEmpty()) {
             return;

--- a/index.js
+++ b/index.js
@@ -110,6 +110,10 @@ class InCallManager {
         _InCallManager.stopRingtone();
     }
 
+    startRingback(ringtone) {
+        _InCallManager.startRingback(ringtone);
+    }
+
     stopRingback() {
         _InCallManager.stopRingback();
     }

--- a/ios/RNInCallManager/RNInCallManager.m
+++ b/ios/RNInCallManager/RNInCallManager.m
@@ -251,7 +251,7 @@ RCT_EXPORT_METHOD(setMicrophoneMute:(BOOL)enable)
     NSLog(@"RNInCallManager.setMicrophoneMute(): ios doesn't support setMicrophoneMute()");
 }
 
-- (void)startRingback:(NSString *)_ringbackUriType
+RCT_EXPORT_METHOD(startRingback:(NSString *)_ringbackUriType)
 {
     // you may rejected by apple when publish app if you use system sound instead of bundled sound.
     NSLog(@"RNInCallManager.startRingback(): type=%@", _ringbackUriType);


### PR DESCRIPTION
In order to hear ringback when starting audio call and have proximity sensor disabled before call is established - I had to make startRingback available in react-native.