### PR TITLE
Library crashes if user changes mute state of device between start() and stop()

### DIFF
--- a/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
+++ b/android/src/main/java/com/zxcpoiu/incallmanager/InCallManagerModule.java
@@ -86,7 +86,6 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
     private boolean origIsSpeakerPhoneOn = false;
     private boolean origIsMicrophoneMute = false;
     private int origAudioMode = AudioManager.MODE_INVALID;
-    private int origRingerMode = AudioManager.RINGER_MODE_NORMAL;
     private boolean defaultSpeakerOn = false;
     private int defaultAudioMode = AudioManager.MODE_IN_COMMUNICATION;
     private int forceSpeakerOn = 0;
@@ -251,7 +250,6 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
     private void storeOriginalAudioSetup() {
         Log.d(TAG, "storeOriginalAudioSetup()");
         if (!isOrigAudioSetupStored) {
-            origRingerMode = audioManager.getRingerMode();
             origAudioMode = audioManager.getMode();
             origIsSpeakerPhoneOn = audioManager.isSpeakerphoneOn();
             origIsMicrophoneMute = audioManager.isMicrophoneMute();
@@ -265,7 +263,6 @@ public class InCallManagerModule extends ReactContextBaseJavaModule implements L
             setSpeakerphoneOn(origIsSpeakerPhoneOn);
             setMicrophoneMute(origIsMicrophoneMute);
             audioManager.setMode(origAudioMode);
-            audioManager.setRingerMode(origRingerMode);
             if (getCurrentActivity() != null) {
                 getCurrentActivity().setVolumeControlStream(AudioManager.USE_DEFAULT_STREAM_TYPE);
             }


### PR DESCRIPTION
Hi,

react-native-incall-manager crashes with the procedure below.

1. Call `start()` in `IncallManagerModule.java` that is bridged to ReactNative.
2. Change mute state of device with pulling navigation items from top of the device
3. Call `stop(final String busytoneUriType) ` in `IncallManagerModule.java` that is bridged to ReactNative.

Then, library crashes due to lack of permission like below.

![device-2018-04-20-180945](https://user-images.githubusercontent.com/1329902/39042805-c478df3e-44c6-11e8-8c06-fbc79c22b833.png)

This crash occurs in `audioManager.setRingerMode()` in `restoreOriginalAudioSetup()`.
This library does not call `audioManager.setRingerMode()` in `start()` method, so it seems that there is no need to restore the initial state in `stop()`.

This PR fixes this crash.

Thanks.