### PR TITLE
add requiresMainQueueSetup method

### DIFF
--- a/ios/RNInCallManager/RNInCallManager.m
+++ b/ios/RNInCallManager/RNInCallManager.m
@@ -1248,6 +1248,11 @@ RCT_EXPORT_METHOD(getIsWiredHeadsetPluggedIn:(RCTPromiseResolveBlock)resolve
     NSLog(@"RNInCallManager.audioPlayerDecodeErrorDidOccur(): player=%@, error=%@", filename, error.localizedDescription);
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
+
 // --- Deprecated in iOS 8.0.
 //- (void)audioPlayerBeginInterruption:(AVAudioPlayer *)player
 //{


### PR DESCRIPTION
Since RN 0.49, `requiresMainQueueSetup` needs to be defined if the module overrides constantsToExport.

For example: 
https://github.com/facebook/react-native/issues/17504
https://github.com/react-community/lottie-react-native/pull/226/files
https://github.com/react-native-community/react-native-video/pull/871/files

Please adding the method